### PR TITLE
Make cache settings configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,12 @@ return [
     'database' => [
         'table' => 'settings',
     ],
+
+    // Cache configurations
+    'cache' => [
+        'key' => 'laravel-settings',
+        'ttl' => 3600,
+    ]
 ];
 ```
 

--- a/README.md
+++ b/README.md
@@ -80,6 +80,7 @@ return [
     'cache' => [
         'key' => 'laravel-settings',
         'ttl' => 3600,
+        'enabled' => true,
     ]
 ];
 ```

--- a/config/settings.php
+++ b/config/settings.php
@@ -12,4 +12,9 @@ return [
     'database' => [
         'table' => 'settings',
     ],
+
+    'cache' => [
+        'key' => 'laravel-settings',
+        'ttl' => 3600,
+    ]
 ];

--- a/config/settings.php
+++ b/config/settings.php
@@ -16,5 +16,6 @@ return [
     'cache' => [
         'key' => 'laravel-settings',
         'ttl' => 3600,
+        'enabled' => true
     ]
 ];

--- a/src/Commands/InstallSettingsCommand.php
+++ b/src/Commands/InstallSettingsCommand.php
@@ -109,13 +109,19 @@ class InstallSettingsCommand extends Command
                 "    // File storage settings\n" .
                 "    'file' => [\n" .
                 "        'path' => '" . addslashes($config['file']['path']) . "',\n" .
-                "    ]\n"
+                "    ],\n"
                 :
                 "    // Database storage settings\n" .
                 "    'database' => [\n" .
                 "        'table' => '" . $config['database']['table'] . "',\n" .
-                "    ]\n"
+                "    ],\n"
             ) .
+            "\n" .
+            "    // Cache configurations \n" .
+            "    'cache' => [\n" .
+            "        'key' => 'laravel-settings',\n" .
+            "        'ttl' => 3600\n" .
+            "    ]\n" .
             "];\n"
         );
     }

--- a/src/Commands/InstallSettingsCommand.php
+++ b/src/Commands/InstallSettingsCommand.php
@@ -120,7 +120,8 @@ class InstallSettingsCommand extends Command
             "    // Cache configurations \n" .
             "    'cache' => [\n" .
             "        'key' => 'laravel-settings',\n" .
-            "        'ttl' => 3600\n" .
+            "        'ttl' => 3600, \n" .
+            "        'enabled' => true\n" .
             "    ]\n" .
             "];\n"
         );

--- a/src/Settings.php
+++ b/src/Settings.php
@@ -21,6 +21,12 @@ class Settings
     /** @var string Format for storing arrays (json/csv/serialize) */
     protected $arrayFormat;
 
+    /** @var string Cache key for settings */
+    protected $cacheKey;
+
+    /** @var int Cache TTL for settings */
+    protected $cacheTtl;
+
     /**
      * Initialize settings manager with storage implementation.
      *
@@ -31,6 +37,8 @@ class Settings
         $this->storage = $storage;
         $this->encrypt = config('settings.encrypt', false);
         $this->arrayFormat = config('settings.array_format', 'json');
+        $this->cacheKey = config('settings.cache.key');
+        $this->cacheTtl = config('settings.cache.ttl');
     }
 
     /**
@@ -40,7 +48,7 @@ class Settings
      */
     public function all(): array
     {
-        return Cache::remember('laravel-settings', 3600, function () {
+        return Cache::remember($this->cacheKey, $this->cacheTtl, function () {
             $data = $this->storage->all();
             return $this->decryptData($data);
         });


### PR DESCRIPTION
This PR introduces configurable cache settings (key and TTL) to provide more flexibility for users, now users can modify cache settings after installing the package via the configuration file.